### PR TITLE
Add HSM group and partitions to output

### DIFF
--- a/controllers/subtenant_controller.go
+++ b/controllers/subtenant_controller.go
@@ -90,6 +90,8 @@ func (r *SubTenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		//
 		fmt.Printf("Reconciling tenant: %+v\n", tenant.Spec.TenantName)
 		fmt.Printf("Tenant State: %+v\n", tenant.Status.State)
+		fmt.Printf("Tenant HSM Partition Name: %+v\n", tenant.Status.HsmPartitionName)
+		fmt.Printf("Tenant HSM Group Label: %+v\n", tenant.Status.HsmGroupLabel)
 		fmt.Printf("Tenant xnames: %+v\n", tenant.Status.Xnames)
 		fmt.Printf("Tenant child namespaces: %+v\n", tenant.Status.ChildNamespaces)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/Cray-HPE/cray-tapms-operator v0.0.0-20220615194753-ade504bea63e // indirect
+	github.com/Cray-HPE/cray-tapms-operator v0.0.0-20220617185922-0ee4e58a6d72 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Cray-HPE/cray-tapms-operator v0.0.0-20220615194753-ade504bea63e h1:aE0qjmNPuxKLDwa30tcqdW3EYSlhEoiqZBsU6JPm7wQ=
 github.com/Cray-HPE/cray-tapms-operator v0.0.0-20220615194753-ade504bea63e/go.mod h1:PHdukll31vgr69XTqT5NXDhC5OlMvKOQlTzMpc/oflI=
+github.com/Cray-HPE/cray-tapms-operator v0.0.0-20220617185922-0ee4e58a6d72 h1:0sf9ISAquO1zKslqswoHRvsEI7pgXsC0wq6e8KD0/1I=
+github.com/Cray-HPE/cray-tapms-operator v0.0.0-20220617185922-0ee4e58a6d72/go.mod h1:PHdukll31vgr69XTqT5NXDhC5OlMvKOQlTzMpc/oflI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Update output to include HSM partition name and group labels -- update to new tapms schema.