### PR TITLE
Cleanup tenant status output

### DIFF
--- a/controllers/subtenant_controller.go
+++ b/controllers/subtenant_controller.go
@@ -113,14 +113,15 @@ func (r *SubTenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// The CRD for the tapms operator has changed -- implement appropriate reconcile
 		// logic for this controller.
 		//
-		fmt.Printf("Reconciling tenant: %+v\n", tenant.Spec.TenantName)
-		fmt.Printf("Tenant State: %+v\n", tenant.Status.State)
-		fmt.Printf("Tenant child namespaces: %+v\n", tenant.Status.ChildNamespaces)
+		fmt.Printf("\nReconciling tenant: '%+v'\n", tenant.Spec.TenantName)
+		fmt.Printf("Tenant State: '%+v'\n", tenant.Status.State)
+		fmt.Printf("Tenant child namespaces: '%+v'\n", tenant.Spec.ChildNamespaces)
 		for _, resource := range tenant.Spec.TenantResources {
-			log.Info(fmt.Sprintf("Tenant HSM Partition Name %s and resource type %s", resource.HsmPartitionName, resource.Type))
-			log.Info(fmt.Sprintf("Tenant HSM Group Label %s and resource type %s", resource.HsmGroupLabel, resource.Type))
-			log.Info(fmt.Sprintf("Tenant xnames %+v and resource type %s", resource.Xnames, resource.Type))
+			fmt.Printf("Tenant HSM Partition Name '%s' and resource type '%s'\n", resource.HsmPartitionName, resource.Type)
+			fmt.Printf("Tenant HSM Group Label '%s' and resource type '%s'\n", resource.HsmGroupLabel, resource.Type)
+			fmt.Printf("Tenant xnames '%+v' and resource type '%s'\n", resource.Xnames, resource.Type)
 		}
+		fmt.Printf("\n")
 	}
 
 	if !subTenantRequest && !tenantRequest {


### PR DESCRIPTION
## Summary and Scope

Some output cleanup in tenant status messages.

## Issues and Related PRs

* Resolves [CASMINST-4719](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4719)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

```
Reconciling tenant: 'vcluster-pepsi'
Tenant State: 'Deployed'
Tenant child namespaces: '[slurm user]'
Tenant HSM Partition Name '' and resource type 'compute'
Tenant HSM Group Label 'pepsi' and resource type 'compute'
Tenant xnames '[x0c3s2b0n0 x0c3s3b0n0]'and resource type 'compute'
```